### PR TITLE
Fix: Correctly calculate the maximum value

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
 def find_maximum(numbers):
     if not numbers:
         return None
-    return max(numbers[:-1])  # Bug: Should use max(numbers) instead of max(numbers[:-1])
+    return max(numbers) # Fixed: Now considers the last element


### PR DESCRIPTION
Fixes the issue where the `find_maximum` function would incorrectly calculate the maximum value when the last element was the largest.